### PR TITLE
Remove possibly unnecessary import YESEXPR

### DIFF
--- a/cycloidFun.py
+++ b/cycloidFun.py
@@ -22,7 +22,6 @@ while True:
         foo = reload(foo)
 """
 
-from locale import YESEXPR
 import math
 from operator import truediv
 import FreeCAD


### PR DESCRIPTION
FreeCAD on Windows complains about this import but removing it seems to cause no problems and it doesn't seem to be used.

Resolves #9, resolves #8